### PR TITLE
Updates for SDK 0.8.1

### DIFF
--- a/RRStructureScanner/Scanner/ViewController+Camera.swift
+++ b/RRStructureScanner/Scanner/ViewController+Camera.swift
@@ -315,6 +315,17 @@ extension ViewController  {
 			
 		}
 		
+        // Read in Apple Intrinsics, if required
+        if let conn = dataOutput.connection(with: .video) {
+            conn.preferredVideoStabilizationMode = .off
+            
+            if #available(iOS 11, *) {
+                if conn.isCameraIntrinsicMatrixDeliverySupported {
+                    conn.isCameraIntrinsicMatrixDeliveryEnabled = true
+                }
+            }
+        }
+        
 		avCaptureSession!.commitConfiguration()
 	}
 

--- a/RRStructureScanner/Scanner/ViewController+SLAM.swift
+++ b/RRStructureScanner/Scanner/ViewController+SLAM.swift
@@ -49,7 +49,7 @@ extension ViewController {
         }
 
         // Initialize the scene.
-        _slamState.scene = STScene.init(context: _display!.context, freeGLTextureUnit: GLenum(GL_TEXTURE2))
+        _slamState.scene = STScene.init(context: _display!.context)
 		
         // Initialize the camera pose tracker.
 		let trackerOptions: [AnyHashable: Any] = [kSTTrackerTypeKey: STTrackerType.depthAndColorBased.rawValue, kSTTrackerTrackAgainstModelKey: true, kSTTrackerQualityKey: STTrackerQuality.accurate.rawValue, kSTTrackerBackgroundProcessingEnabledKey: true]


### PR DESCRIPTION
Not sure if this happened on the 0.8 or 0.8.1 update, but Structure added some things which required `conn.isCameraIntrinsicMatrixDeliveryEnabled` to be set to true *if* the device supports it (note that at present this appears to be broken for the iPad Air 2, but works fine on other devices).

See the forums [here](https://forums.structure.io/t/announcing-structure-sdk-0-8-1-improved-trackers-and-turntable-support/8281/23) for more info.

Not sure why the edit is needed to `ViewController+SLAM.swift`, all I know is that it wouldn't compile on my Mac (XCode 10, Swift 4.1).